### PR TITLE
Added missing escape for apostrophe

### DIFF
--- a/DiscreetAppRate/src/main/res/values-fr/strings.xml
+++ b/DiscreetAppRate/src/main/res/values-fr/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="dra_rate_app">Tu l'aimes? Note-la!</string>
+    <string name="dra_rate_app">Tu l\'aimes? Note-la!</string>
 </resources>


### PR DESCRIPTION
Eclipse throws:

```
\discreet-app-rate\DiscreetAppRate\src\main\res\values-fr\strings.xml:2: error: Apostrophe not preceded by \ (in Tu l'aimes? Note-la!)
```
