### PR TITLE
Fix an issue which will show the AppRateBar behind the ActionBar

### DIFF
--- a/DiscreetAppRate/src/main/java/fr/nicolaspomepuy/discreetapprate/AppRate.java
+++ b/DiscreetAppRate/src/main/java/fr/nicolaspomepuy/discreetapprate/AppRate.java
@@ -587,20 +587,13 @@ public class AppRate {
                 if (isTranslucent) {
                     if (debug) LogD("Activity is translucent");
 
-
-                    int actionBarHeight = 0;
-                    //ActionBar size
-                    if (activity.getActionBar() != null) {
-                        actionBarHeight = activity.getActionBar().getHeight();
-                    }
-
                     if (container.getParent() instanceof FrameLayout) {
                         FrameLayout.LayoutParams lp = (FrameLayout.LayoutParams) container.getLayoutParams();
-                        lp.topMargin = Utils.getStatusBarHeight(activity) + actionBarHeight;
+                        lp.topMargin = Utils.getActionStatusBarHeight(activity);
                         container.setLayoutParams(lp);
                     } else if (container.getParent() instanceof RelativeLayout) {
                         RelativeLayout.LayoutParams lp = (RelativeLayout.LayoutParams) container.getLayoutParams();
-                        lp.topMargin = Utils.getStatusBarHeight(activity) + actionBarHeight;
+                        lp.topMargin = Utils.getActionStatusBarHeight(activity);
                         container.setLayoutParams(lp);
                     }
                 }
@@ -652,6 +645,7 @@ public class AppRate {
         }
 
     }
+
 
     @SuppressLint("NewApi")
     private void commitEditor() {

--- a/DiscreetAppRate/src/main/java/fr/nicolaspomepuy/discreetapprate/Utils.java
+++ b/DiscreetAppRate/src/main/java/fr/nicolaspomepuy/discreetapprate/Utils.java
@@ -9,6 +9,8 @@ import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Build;
+import android.util.TypedValue;
 
 import java.lang.reflect.Field;
 import java.util.Date;
@@ -114,6 +116,20 @@ public class Utils {
         return getInternalDimensionSize(activity.getResources(), STATUS_BAR_HEIGHT_RES_NAME);
     }
 
+
+    public static int getActionStatusBarHeight(Activity activity) {
+        return getStatusBarHeight(activity) + getActionBarHeight(activity);
+    }
+
+    public static int getActionBarHeight(Activity activity) {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            TypedValue tv = new TypedValue();
+            if (activity.getTheme().resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
+                return TypedValue.complexToDimensionPixelSize(tv.data, activity.getResources().getDisplayMetrics());
+            }
+        }
+        return 0;
+    }
 
     public static int getInternalDimensionSize(Resources res, String key) {
         int result = 0;


### PR DESCRIPTION
Create a new method to get the ActionBarHeight
--> Move this method to the Utils like your method getStatusBarHeight

With the previous attempt to get the ActionBarSize it caused some issue if the TranslucentDecorView was used.
See the screenshot on the bottom.

Now it should work in 90% of the cases. It will still cause issues if someone has a custom-rom with a different ActionBarSize.

For my private projects i use the DrawInsetsLayout but we can't use it here.

![screenshot_2014-05-25-13-22-43](https://cloud.githubusercontent.com/assets/1476232/3076883/6a1832e4-e401-11e3-871a-0eb115a6b68b.png)
