### PR TITLE
Fixes a possible NPE if the app with the given packageName is not installed

### DIFF
--- a/DiscreetAppRate/src/main/java/fr/nicolaspomepuy/discreetapprate/AppRate.java
+++ b/DiscreetAppRate/src/main/java/fr/nicolaspomepuy/discreetapprate/AppRate.java
@@ -370,6 +370,9 @@ public class AppRate {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
             Date installDate = Utils.installTimeFromPackageManager(activity.getPackageManager(), this.packageName);
+            if (installDate == null) {
+                installDate = Utils.installTimeFromPackageManager(activity.getPackageManager(), activity.getPackageName());
+            }
             Date now = new Date();
             if (now.getTime() - installDate.getTime() < installedSince) {
                 if (debug)


### PR DESCRIPTION
If the user of the library calls Apprate.with(activity, packageName) but the package with the given package name is not installed the app crashes with a NPE in line 374. That's because no install date for the package could be retrieved.

In this case this solution falls back to the old way and gets install date by using the current package's install date.

This bug most likely happens only in debug mode when a user is testing his app with a different package name but hasn't yet the proper app installed.
