### PR TITLE
madeText size bigger and dynamic

### DIFF
--- a/DiscreetAppRate/src/main/res/layout/app_rate.xml
+++ b/DiscreetAppRate/src/main/res/layout/app_rate.xml
@@ -18,6 +18,7 @@
             android:layout_height="match_parent"
             android:gravity="center_vertical"
             android:id="@+id/dar_rate_element"
+            android:textAppearance="?android:attr/textAppearanceMedium"
             android:textColor="@android:color/white"
             android:layout_toLeftOf="@+id/dar_close"/>
 


### PR DESCRIPTION
prior to this enhancement the rate text appeared too small.
_Before_
![img_20150915_220910](https://cloud.githubusercontent.com/assets/6098606/9894883/280d8790-5bf7-11e5-875f-5185aa1b3ac9.JPG)

_After_
![img_20150915_220959](https://cloud.githubusercontent.com/assets/6098606/9894893/43c35a8c-5bf7-11e5-8172-9da44a83e576.JPG)
